### PR TITLE
Hide scores for learners if hide scores setting is enabled

### DIFF
--- a/long_answer_xblock/long_answer.py
+++ b/long_answer_xblock/long_answer.py
@@ -559,6 +559,7 @@ class LongAnswerXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMixin, XBlock)
             "upload_allowed": self.upload_allowed(submission_data=submission),
             "solution": solution,
             "base_asset_url": StaticContent.get_base_url_path_for_course_assets(self.location.course_key),
+            "answer_available": self.answer_available()
         }
 
     def staff_grading_data(self):

--- a/long_answer_xblock/templates/long_answer_xblock/show.html
+++ b/long_answer_xblock/templates/long_answer_xblock/show.html
@@ -36,9 +36,13 @@
         <% } %>
         <p>
           <% if (graded) { %>
-            {% blocktrans %}Your score is <%= graded.score %> / <%= max_score %>{% endblocktrans %}<br/>
-            <% if (graded.comment) { %>
-              <b>{% trans "Instructor comment" %}</b> <%= graded.comment %><br/>
+            <% if(answer_available) { %>
+              {% blocktrans %}Your score is <%= graded.score %> / <%= max_score %>{% endblocktrans %}<br/>
+              <% if (graded.comment) { %>
+                <b>{% trans "Instructor comment" %}</b> <%= graded.comment %><br/>
+              <% } %>
+            <% } else { %>
+              {% trans "Scores and remarks are hidden." %}
             <% } %>
           <% } else if (submitted.finalized) { %>
             {% trans "This problem has not been graded yet." %}


### PR DESCRIPTION
We can not hide scores from section visibility settings but there is SGA setting that we can use to achieve required behavior as shown in attached SS. This SGA setting is already there but was not working correctly so I did some code changes to fix it.

![image](https://user-images.githubusercontent.com/42185078/209795199-23d7c7dc-5242-459e-b8d8-b3aabc2e73af.png)
