### PR TITLE
If data is edited after saved, submit latest data instead of saved data

### DIFF
--- a/long_answer_xblock/long_answer.py
+++ b/long_answer_xblock/long_answer.py
@@ -245,6 +245,8 @@ class LongAnswerXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMixin, XBlock)
             # Editing the Submission record directly since the API doesn't support it
             submission = Submission.objects.get(uuid=submission_data['uuid'])
             if not submission.answer.get('finalized'):
+                if request.params.get('assignment_answer'):
+                    submission.answer['student_answer'] = request.params['assignment_answer']
                 submission.answer['finalized'] = True
                 submission.submitted_at = django_now()
                 submission.save()


### PR DESCRIPTION
### Problem:
If student has written something in the text area and saved, then later added more content and hit "Submit" button directly, It submits the initial saved content rather submitting the content written in the text area. Ideally It should submit the written content. It seems a bug, pls discuss with team. It's in long answer